### PR TITLE
Add DynamoDB backend management CLI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+#! /usr/bin/env python
 #  Copyright (c) 2020 Zero A.E., LLC
 #
 #  This program is free software: you can redistribute it and/or modify

--- a/app.py
+++ b/app.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python
 #  Copyright (c) 2020 Zero A.E., LLC
 #
 #  This program is free software: you can redistribute it and/or modify

--- a/chalicelib/db.py
+++ b/chalicelib/db.py
@@ -14,7 +14,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-def db_init():
+def db_init() -> bool:
     from chalicelib.models import ModuleModel
 
     if not ModuleModel.exists():
@@ -22,9 +22,25 @@ def db_init():
             read_capacity_units=1, write_capacity_units=1, wait=True
         )
 
+    return ModuleModel.exists()
 
-def db_destroy():
+
+def db_destroy() -> bool:
     from chalicelib.models import ModuleModel
 
     if ModuleModel.exists():
         ModuleModel.delete_table()
+
+    return not ModuleModel.exists()
+
+
+def db_dump(filename):
+    from chalicelib.models import ModuleModel
+
+    ModuleModel.dump(filename)
+
+
+def db_load(filename):
+    from chalicelib.models import ModuleModel
+
+    ModuleModel.load(filename)

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ channels:
 dependencies:
   # Development Dependencies
   - chalice 1.12
+  - click >=6,<8
   - ipython
   - liquidprompt
   - python 3.7

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,98 @@
+#! /usr/bin/env python
+#  Copyright (c) 2020 Zero A.E., LLC
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import json
+import os
+
+import click
+
+from chalicelib import db
+
+
+def _get_chalice_stages():
+    config = _get_chalice_config()
+    stages: dict = config["stages"]
+    return list(stages.keys())
+
+
+def _get_chalice_config():
+    with open(".chalice/config.json") as f:
+        config = json.load(f)
+    return config
+
+
+def _apply_chalice_stage(stage):
+    config = _get_chalice_config()
+    stage_config: dict = config["stages"][stage]
+    env_vars: dict = stage_config.get("environment_variables", {})
+    for k, v in env_vars.items():
+        if k not in os.environ:
+            os.environ[k] = v
+
+
+@click.group()
+@click.option(
+    "--stage",
+    help="The Chalice stage",
+    type=click.Choice(_get_chalice_stages()),
+    default=_get_chalice_stages()[0],
+    show_default=True,
+)
+def go(stage) -> None:
+    """
+    The Terraform Registry Management CLI
+    """
+    _apply_chalice_stage(stage)
+
+
+@go.group()
+def db():
+    """
+    Manage the DynamoDB backend (init, destroy, backup, restore).
+    """
+
+
+@db.command(name="init")
+def db_init():
+    """Initializes the backend."""
+    return db.db_init()
+
+
+@db.command(name="destroy")
+def db_destroy():
+    """Destroys the backend."""
+    click.confirm(
+        "There is no coming back from this... are you sure you want to continue?",
+        abort=True,
+    )
+    return db.db_destroy()
+
+
+@db.command(name="backup")
+@click.argument("filename", type=click.Path(dir_okay=False, writable=True))
+def db_backup(filename):
+    """Backups the backend content."""
+    db.db_dump(filename)
+
+
+@db.command(name="restore")
+@click.argument("filename", type=click.Path(exists=True, dir_okay=False))
+def db_restore(filename):
+    """Restores the backend content."""
+    db.db_load(filename)
+
+
+if __name__ == "__main__":
+    go()


### PR DESCRIPTION
- The CLI currently allows you to init, destroy, backup and restore the backend.

The sysadmin can use the CLI to:
  - Initialize the DB backend: `./manage.py db init`
  - Destroy the DB backend: `./manage.py db destroy`
  - Dump/Backup the DB backend: `./manage.py db backup <out filename>`
  - Restore the DB backend from a backup: `./manage.py db restore <in file>`

ref: #2