### PR TITLE
Add record level operations to manage.py

### DIFF
--- a/chalicelib/models.py
+++ b/chalicelib/models.py
@@ -70,13 +70,11 @@ class ModuleModel(Model):
     version = UnicodeAttribute(range_key=True)
     getter_url = UnicodeAttribute()
 
-    source = UnicodeAttribute(null=True)
-
-    published_at = UTCDateTimeAttribute(default_for_new=datetime.utcnow)
-
     verified = BooleanAttribute(null=True)
 
     owner = UnicodeAttribute(null=True)
     description = UnicodeAttribute(null=True)
+    source = UnicodeAttribute(null=True)
 
+    published_at = UTCDateTimeAttribute(default_for_new=datetime.utcnow)
     downloads = NumberAttribute(default_for_new=0)

--- a/chalicelib/models.py
+++ b/chalicelib/models.py
@@ -68,6 +68,7 @@ class ModuleModel(Model):
 
     module_name = ModuleNameAttribute(hash_key=True)
     version = UnicodeAttribute(range_key=True)
+    getter_url = UnicodeAttribute()
 
     source = UnicodeAttribute(null=True)
 

--- a/chalicelib/models.py
+++ b/chalicelib/models.py
@@ -68,7 +68,8 @@ class ModuleModel(Model):
 
     module_name = ModuleNameAttribute(hash_key=True)
     version = UnicodeAttribute(range_key=True)
-    source = UnicodeAttribute()
+
+    source = UnicodeAttribute(null=True)
 
     published_at = UTCDateTimeAttribute(default_for_new=datetime.utcnow)
 

--- a/chalicelib/modules.py
+++ b/chalicelib/modules.py
@@ -177,7 +177,7 @@ def download(namespace: str, name: str, provider: str, version: str):
     try:
         module_name = ModuleName(namespace, name, provider)
         module = ModuleModel.get(module_name, range_key=version)
-        if module.source is None:
+        if module.getter_url is None:
             raise ChaliceViewError(
                 msg=f"{namespace}/{name}/{provider}/{version} is missing the `source` attribute."
             )
@@ -185,7 +185,7 @@ def download(namespace: str, name: str, provider: str, version: str):
         return Response(
             body=None,
             status_code=HTTPStatus.NO_CONTENT,
-            headers={"X-Terraform-Get": module.source},
+            headers={"X-Terraform-Get": module.getter_url},
         )
     except DoesNotExist as dne:
         return Response(

--- a/environment.yml
+++ b/environment.yml
@@ -11,11 +11,13 @@ dependencies:
   - liquidprompt
   - python 3.7
   - pre-commit
+  - requests
   # - ngrok, open an account at ngrok.com
 
   # Runtime Dependencies (must match requirements.txt)
   - environs
   - pynamodb
+  - python-dateutil
   - semver
 
   # Test Dependencies

--- a/manage.py
+++ b/manage.py
@@ -120,9 +120,23 @@ fqvm_argument = click.argument(
 
 @record.command("create")
 @fqvm_argument
-def record_create(fqvmn):
+@click.argument("getter-url", metavar="getter-url")
+def record_create(fqvmn, getter_url):
     """
     Create a new Terraform Module Record
+
+    Hashicorp's `getter-url` format supports a variety of protocols,
+    and implements various tricks to do certain things. For full-details
+    on the URL format see http://bit.ly/2Wxgxk7.
+
+    \b
+    Examples:
+        - Local:
+              ./local
+        - GitHub:
+              github.com/terraform-aws-modules/terraform-aws-vpc?ref=2.29.0
+        - S3:
+              s3::http://s3.amazonaws.com/bucket/hello.txt
     """
     from chalicelib.models import ModuleModel, ModuleName
 
@@ -133,7 +147,9 @@ def record_create(fqvmn):
         return 1
     except ModuleModel.DoesNotExist as dne:
         module = ModuleModel(
-            module_name=ModuleName(namespace, name, provider), version=version
+            module_name=ModuleName(namespace, name, provider),
+            version=version,
+            getter_url=getter_url,
         )
         module.save()
 
@@ -151,7 +167,7 @@ def record_delete(fqvmn):
     try:
         module = ModuleModel.get(hash_key=module_name, range_key=version)  # noqa
         module.delete()
-    except ModuleModel.DoesNotExist as dne:
+    except ModuleModel.DoesNotExist:
         pass
 
 

--- a/manage.py
+++ b/manage.py
@@ -125,7 +125,11 @@ fqvmn_argument = click.argument(
 @record.command("create")
 @fqvmn_argument
 @click.argument("getter-url", metavar="getter-url")
-def record_create(fqvmn, getter_url):
+@click.option("--verified/--not-verified", default=False, show_default=True)
+@click.option("--owner", type=click.STRING, help="The module owner.")
+@click.option("--description", type=click.STRING, help="The module description.")
+@click.option("--source", type=click.STRING, help="The source code location.")
+def record_create(fqvmn, getter_url, verified, owner, description, source):
     """
     Create a new Terraform Module Record.
 
@@ -154,6 +158,10 @@ def record_create(fqvmn, getter_url):
             module_name=ModuleName(namespace, name, provider),
             version=version,
             getter_url=getter_url,
+            verified=verified if verified else None,
+            owner=owner,
+            description=description,
+            source=source,
         )
         module.save()
 

--- a/manage.py
+++ b/manage.py
@@ -191,6 +191,7 @@ def record_import():
     """
     Import Terraform module from external sources
     """
+    pass
 
 
 def discover_modules_v1(registry):

--- a/manage.py
+++ b/manage.py
@@ -61,21 +61,21 @@ def go(stage) -> None:
     _apply_chalice_stage(stage)
 
 
-@go.group()
-def db():
+@go.group("db")
+def db_group():
     """
     Manage the DynamoDB backend (init, destroy, backup, restore).
     """
     pass
 
 
-@db.command(name="init")
+@db_group.command(name="init")
 def db_init():
     """Initializes the backend."""
     return db.db_init()
 
 
-@db.command(name="destroy")
+@db_group.command(name="destroy")
 def db_destroy():
     """Destroys the backend."""
     click.confirm(
@@ -85,7 +85,7 @@ def db_destroy():
     return db.db_destroy()
 
 
-@db.command(name="backup")
+@db_group.command(name="backup")
 @click.argument("filename", type=click.Path(dir_okay=False, writable=True))
 def db_backup(filename):
     """Backups the backend content."""
@@ -93,7 +93,7 @@ def db_backup(filename):
     return 0
 
 
-@db.command(name="restore")
+@db_group.command(name="restore")
 @click.argument("filename", type=click.Path(exists=True, dir_okay=False))
 def db_restore(filename):
     """Restores the backend content."""

--- a/manage.py
+++ b/manage.py
@@ -123,7 +123,7 @@ fqvm_argument = click.argument(
 @click.argument("getter-url", metavar="getter-url")
 def record_create(fqvmn, getter_url):
     """
-    Create a new Terraform Module Record
+    Create a new Terraform Module Record.
 
     Hashicorp's `getter-url` format supports a variety of protocols,
     and implements various tricks to do certain things. For full-details
@@ -158,7 +158,7 @@ def record_create(fqvmn, getter_url):
 @fqvm_argument
 def record_delete(fqvmn):
     """
-    Delete a Terraform Module Record
+    Delete a Terraform Module Record.
     """
     from chalicelib.models import ModuleModel, ModuleName
 
@@ -169,6 +169,17 @@ def record_delete(fqvmn):
         module.delete()
     except ModuleModel.DoesNotExist:
         pass
+
+
+@record.command("list")
+def record_list():
+    """
+    Lists all the Terraform Modules in backend.
+    """
+    from chalicelib.models import ModuleModel
+
+    for module in ModuleModel.scan(attributes_to_get=["module_name", "version"]):
+        click.echo(f"{module.module_name}/{module.version}")
 
 
 if __name__ == "__main__":

--- a/manage.py
+++ b/manage.py
@@ -194,21 +194,13 @@ def record_list():
         click.echo(f"{module.module_name}/{module.version}")
 
 
-@record.group("import")
-def record_import():
-    """
-    Import Terraform module from external sources
-    """
-    pass
-
-
 def discover_modules_v1(registry):
     url = f"https://{registry}/.well-known/terraform.json"
     r = requests.get(url)
     return urljoin(url, r.json()["modules.v1"])
 
 
-@record_import.command("registry")
+@record.command("import")
 @fqvmn_argument
 @click.option(
     "--registry",
@@ -216,9 +208,9 @@ def discover_modules_v1(registry):
     default="registry.terraform.io",
     show_default=True,
 )
-def record_import_registry(fqvmn, registry):
+def record_import(fqvmn, registry):
     """
-    Import Terraform Module metadata from (private) registry
+    Import a new Terraform Module from an external registry.
     """
     from chalicelib.models import ModuleName, ModuleModel
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 environs
 pynamodb
+python-dateutil
 semver

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -107,7 +107,7 @@ def test_download_success(
 
     def mock_get(hash_key, **kwargs):
         rv = ModuleModel(hash_key, version=kwargs["range_key"])
-        rv.source = "./name"
+        rv.getter_url = "./name"
         return rv
 
     def mock_save(*args, **kwargs):


### PR DESCRIPTION
As part of #2, this PR will add the ability for the application administrator to:

  - [x] create a module record
      `./manage.py record create <module>/<name>/<provider>/<version> <go-getter-url>`
      We can also populate the `verified`, `owner`, `description` and `source` attributes using --options
  - [x] delete a module record
      `./manage.py record delete <module>/<name>/<provider>/<version>`
  - [x] import module records from registry.terraform.io:
      `./manage.py record import [--registry registry.terraform.io] <module>/<name>/<provider>/<version>`
  - <strike> import module records from local file </strike>