### PR TITLE
Improve local startup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Zero A.E.'s [12-Factor][12-factor] codebase of the [Terraform Registry API][regi
     docker-compose up -d
     ```
    
+1. Wait until the `app`, `backend` and `manage` services are healthy
+    ```shell script
+    watch docker-compose ps  
+    ```
+   
 1. Attach to the Management container 
     ```shell script
     docker attach terraform-registry_manage_1

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Zero A.E.'s [12-Factor][12-factor] codebase of the [Terraform Registry API][regi
 1. Clone the secrets (submodules did not work)
     ```shell script
     git clone keybase://team/zeroae/terraform-registry-secrets secrets
+   
+    # Fix the acme.json file permissions. 600 is not committable to Git
+    find . -type f -name acme.json -exec chmod 600 {} \;
     ```
    
 1. Create conda environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       context: .
       dockerfile: manage.Dockerfile
     image: zeroae/terraform-registry-manage:local
+    healthcheck:
+      test: "/bin/true"
     links:
       - reverse-proxy:tf.$ACME_DNS_SUFFIX
     stdin_open: true
@@ -47,14 +49,14 @@ services:
   reverse-proxy:
     # The official v2 Traefik docker image
     image: traefik:v2.1
-    # Enables the web UI and tells Traefik to listen to docker
     command:
       - --api.insecure=true
-      - --providers.docker
-      - --entryPoints.web.address=:80
-      - --entryPoints.websecure.address=:443
       - --certificatesResolvers.default.acme.storage=/etc/traefik/acme/acme.json
       - --certificatesResolvers.default.acme.dnsChallenge.provider=$ACME_DNS_PROVIDER
+      - --entryPoints.web.address=:80
+      - --entryPoints.websecure.address=:443
+      - --ping=true
+      - --providers.docker
     ports:
       # The HTTP(s) port
       - "80:80"
@@ -64,5 +66,7 @@ services:
     volumes:
       # So that Traefik can listen to Docker events
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # So that Trafik can read/store ACME Certificates
       - ./secrets/$ACME_DNS_SUFFIX/acme:/etc/traefik/acme
+      # So that Traefik can talk to AWS for Route53 DNS Challenges
       - ./secrets/aws:/root/.aws/:ro


### PR DESCRIPTION
  - [x] Handle acme.json file mode issue  (Close #33)
  - [x] Ask user to wait until the services are actually healthy. "Chalice" takes quite a bit of time to do that.