### PR TITLE
Documentation changes a result of deploying the dev stage api on aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .chalice/deployments/
 .chalice/venv/
 
+# python cache
+__pycache__
+
 # Terraform modules
 .terraform/
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ Zero A.E.'s [12-Factor][12-factor] codebase of the [Terraform Registry API][regi
 1. Use Chalice to (re)deploy the `dev` stage to AWS
     ```shell script
     export AWS_CONFIG_FILE="./secrets/aws/config"
-    chalice --stage=dev deploy
+    chalice deploy --stage=dev
     ```
+   You may also set the `AWS_DEFAULT_PROFILE` environment variable to control where the API is deployed
 
 1. Initialize the Database
     ```shell script


### PR DESCRIPTION
* `.gitignore` for  `__pycache__`
* Use of profiles
* Moved the --stage command to the correct location in the CLI invocation