### PR TITLE
Support for region specification

### DIFF
--- a/chalicelib/config.py
+++ b/chalicelib/config.py
@@ -25,3 +25,4 @@ with env.prefixed("ZTR_"):
     with env.prefixed("DYNAMODB_"):
         ZTR_DYNAMODB_URL = env.str("URL", default=None)
         ZTR_DYNAMODB_TABLE_PREFIX = env.str("TABLE_PREFIX")
+        ZTR_DYNAMODB_REGION = env.str("REGION", default="us-east-1")

--- a/chalicelib/models.py
+++ b/chalicelib/models.py
@@ -25,7 +25,7 @@ from pynamodb.attributes import (
 from pynamodb.constants import STRING
 from pynamodb.models import Model
 
-from .config import ZTR_DYNAMODB_TABLE_PREFIX, ZTR_DYNAMODB_URL
+from .config import ZTR_DYNAMODB_TABLE_PREFIX, ZTR_DYNAMODB_URL, ZTR_DYNAMODB_REGION
 
 
 @dataclass
@@ -65,6 +65,7 @@ class ModuleModel(Model):
     class Meta:
         host = ZTR_DYNAMODB_URL
         table_name = f"{ZTR_DYNAMODB_TABLE_PREFIX}Module"
+        region = ZTR_DYNAMODB_REGION
 
     module_name = ModuleNameAttribute(hash_key=True)
     version = UnicodeAttribute(range_key=True)


### PR DESCRIPTION
Leveraging the existing pattern of environment variables setting the dynamodb url and table name the region specification has been added.